### PR TITLE
Opengl to native backend

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -12,12 +12,14 @@ Required:
 * [OpenUSD v24.08](https://github.com/PixarAnimationStudios/OpenUSD) or newer
 
 Embedded:
-* [glew](https://github.com/Perlmint/glew-cmake)
-* [glfw v3.4](https://github.com/glfw/glfw)
 * [imgui v1.90.9](https://github.com/ocornut/imgui)
 * [ImGuizmo v1.83](https://github.com/CedricGuillemet/ImGuizmo)
 * [ImGuiFileDialog v0.6.7](https://github.com/aiekick/ImGuiFileDialog)
 * [ImGuiColorTextEdit](https://github.com/BalazsJako/ImGuiColorTextEdit)
+
+Optional (if OpenGL enabled):
+* [glew](https://github.com/Perlmint/glew-cmake)
+* [glfw v3.4](https://github.com/glfw/glfw)
 
 ## Getting Started
 
@@ -61,9 +63,14 @@ Within the cloned ImGuiHydraEditor, create a build folder and run cmake from thi
 ```bash
 mkdir build
 cd build
-cmake -Dpxr_DIR=/path/to/OpenUSD/build/folder -DCMAKE_INSTALL_PREFIX=/path/to/install/folder ..
+cmake -Dpxr_DIR=/path/to/OpenUSD/build/folder -DOpenSubdiv_DIR=/path/to/OpenUSD/build/folder/lib/cmake/OpenSubdiv -DCMAKE_INSTALL_PREFIX=/path/to/install/folder ..
 make
 make install
+```
+
+You can also use the following flag to force the use of OpenGL (e.g. on Mac instead of Metal):
+```bash
+-DFORCE_OPENGL=ON
 ```
 
 ### Run ImGuiHydraEditor
@@ -72,19 +79,6 @@ if everything went well, 3 new folders are created in your `/path/to/install/fol
 
 You can then run the ImGuiHydraEditor application as follow:
 
-Linux:
 ```bash
-export LD_LIBRARY_PATH=/path/to/OpenUSD/build/folder/lib:/path/to/OpenUSD/build/folder/lib64:$LD_LIBRARY_PATH
-./ImGuiHydraEditor
-```
-
-MacOS:
-```bash
-export DYLD_LIBRARY_PATH=/path/to/OpenUSD/build/folder/lib:$DYLD_LIBRARY_PATH
-./ImGuiHydraEditor
-```
-
-You can optionally load a USD file directly using the following command:
-```bash
-./ImGuiHydraEditor /input/file.usd
+/path/to/install/folder/bin/ImGuiHydraEditor
 ```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,22 +12,66 @@ find_package(OpenGL REQUIRED)
 
 add_subdirectory(vendors)
 
-file(GLOB_RECURSE SRC_CPP
+file(GLOB SRC_CPP
   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
   "src/*.cpp"
+  "src/layouts/*.cpp"
+  "src/models/*.cpp"
+  "src/sceneindices/*.cpp"
+  "src/style/*.cpp"
+  "src/views/*.cpp"
 )
-file(GLOB_RECURSE SRC_H
+
+file(GLOB SRC_H
   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
   "src/*.h"
+  "src/layouts/*.h"
+  "src/models/*.h"
+  "src/sceneindices/*.h"
+  "src/style/*.h"
+  "src/views/*.h"
+  "src/backends/*.h"
 )
+
+set(LIBRARIES
+    ${PXR_LIBRARIES}
+    imgui
+    imguizmo
+    imguicolortextedit
+    imguifiledialog
+)
+
+# Add the backend for the graphics according to the OS
+if(APPLE AND NOT FORCE_OPENGL)
+    list(APPEND SRC_CPP "src/backends/metal.mm")
+    list(APPEND LIBRARIES
+            "-framework Cocoa"
+            "-framework Metal"
+            "-framework QuartzCore"
+            "-framework GameController"
+            "-framework AppKit"
+            "-framework MetalKit"
+    )
+else()
+    list(APPEND SRC_CPP "src/backends/opengl.cpp")
+    list(APPEND LIBRARIES
+        libglew_static
+        glfw
+    )
+endif()
 
 # Configure RPATH so libraries are found after make install
 if(APPLE)
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 elseif(UNIX)
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib64")
+elseif(WIN32)
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE
+            NOMINMAX
+            _USE_MATH_DEFINES
+    )
 endif()
-
 
 add_executable(${PROJECT_NAME} ${SRC_CPP} ${SRC_H})
 
@@ -38,25 +82,10 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        ${PXR_LIBRARIES}
-        libglew_static
-        glfw
-        imgui
-        imguizmo
-        imguicolortextedit
-        imguifiledialog
+        ${LIBRARIES}
 )
 
 include_directories(${PROJECT_NAME} ${PXR_INCLUDE_DIRS})
-
-if(WIN32)
-    target_compile_definitions(${PROJECT_NAME}
-        PRIVATE
-            NOMINMAX
-            _USE_MATH_DEFINES
-    )
-endif()
-
 
 # --------------- install section ---------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(GNUInstallDirs)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(X11)
 find_package(pxr REQUIRED)
 find_package(OpenGL REQUIRED)
 

--- a/src/backends/backend.h
+++ b/src/backends/backend.h
@@ -1,13 +1,51 @@
-// backend.h
+/**
+ * @file backend.h
+ * @author Raphael Jouretz (rjouretz.com)
+ * @brief Headers containing the functions to interact with
+ * the graphic backend (create window, get texture, ...).
+ * The according implementation get bound during compilation.
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+
 #pragma once
 
-#include "pxr/imaging/hgi/texture.h"
+/**
+ * 
+ */
+#include "pxr/imaging/hd/renderBuffer.h"
+#include "pxr/imaging/hgi/hgi.h"
 
-void InitBackend();
+/**
+ * @brief Initialize the backend and create a window
+ *
+ * @param title the title of the created window
+ * @param width the width of the created window
+ * @param height the height of the created window
+ * 
+ * @return 0 if successfully inititalized. Otherwise return non zero.
+ */
+int InitBackend(const char* title, int width, int height);
+
+/**
+ * @brief Run the main loop of the window
+ *
+ * @param callback the callback to a function called every frame
+ */
+void RunBackend(void (*callback)());
+
+/**
+ * @brief Shutdown the backend
+ */
 void ShutdownBackend();
-bool ShouldCloseApp();
-void PollEvents();
-bool BeginFrame();
-void EndFrame();
 
-void *GetPointerToHgiTextureBackend(pxr::HgiTextureHandle texHandle, float width, float height);
+/**
+ * @brief Retrieve a pointer to texture data of the given buffer
+ *
+ * @param buffer the hydra render buffer the texture data
+ * @param hgi the hgi related to the buffer
+ * 
+ * @return a pointer to the texture data
+ */
+void *GetPointerToTextureBackend(pxr::HdRenderBuffer* buffer, pxr::Hgi* hgi);

--- a/src/backends/backend.h
+++ b/src/backends/backend.h
@@ -1,0 +1,13 @@
+// backend.h
+#pragma once
+
+#include "pxr/imaging/hgi/texture.h"
+
+void InitBackend();
+void ShutdownBackend();
+bool ShouldCloseApp();
+void PollEvents();
+bool BeginFrame();
+void EndFrame();
+
+void *GetPointerToHgiTextureBackend(pxr::HgiTextureHandle texHandle, float width, float height);

--- a/src/backends/metal.mm
+++ b/src/backends/metal.mm
@@ -1,0 +1,155 @@
+// backend.mm
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/CAMetalLayer.h>
+#import <Metal/Metal.h>
+
+#include "imgui.h"
+#include "imgui_impl_metal.h"
+#include "imgui_impl_osx.h"
+#include "backend.h"
+
+static NSWindow* window = nil;
+static NSView* contentView = nil;
+static CAMetalLayer* metalLayer = nil;
+static id<MTLDevice> device = nil;
+static id<MTLCommandQueue> commandQueue = nil;
+static bool shouldClose = false;
+static bool backendReady = false;
+
+static id<CAMetalDrawable> currentDrawable = nil;
+static MTLRenderPassDescriptor* currentRenderPassDescriptor = nil;
+
+@interface AppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+@end
+
+@implementation AppDelegate
+- (void)applicationDidFinishLaunching:(NSNotification*)notification {
+    NSRect frame = NSMakeRect(0, 0, 1280, 720);
+    window = [[NSWindow alloc] initWithContentRect:frame
+                                          styleMask:(NSWindowStyleMaskTitled |
+                                                     NSWindowStyleMaskClosable |
+                                                     NSWindowStyleMaskResizable)
+                                            backing:NSBackingStoreBuffered
+                                              defer:NO];
+    [window setTitle:@"ImGui Metal App"];
+    [window setDelegate:self];
+    [window makeKeyAndOrderFront:nil];
+
+    device = MTLCreateSystemDefaultDevice();
+    commandQueue = [device newCommandQueue];
+
+    contentView = [[NSView alloc] initWithFrame:frame];
+    [window setContentView:contentView];
+
+    metalLayer = [CAMetalLayer layer];
+    metalLayer.device = device;
+    metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    metalLayer.framebufferOnly = YES;
+    metalLayer.contentsScale = window.backingScaleFactor;
+    metalLayer.frame = contentView.bounds;
+    [contentView setLayer:metalLayer];
+    [contentView setWantsLayer:YES];
+
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+
+    ImGui_ImplMetal_Init(device);
+    ImGui_ImplOSX_Init(contentView);
+
+    backendReady = true;
+}
+
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender {
+    return YES;
+}
+
+- (void)windowWillClose:(NSNotification *)notification {
+    shouldClose = true;
+    [metalLayer removeFromSuperlayer];
+    metalLayer = nil;
+    contentView = nil;
+    window = nil;
+}
+@end
+
+void InitBackend() {
+    [NSApplication sharedApplication];
+    static AppDelegate* delegate = [[AppDelegate alloc] init];
+    [NSApp setDelegate:delegate];
+    [NSApp activateIgnoringOtherApps:YES];
+    [NSApp finishLaunching];
+
+    // Wait until AppDelegate finishes initialization
+    while (!backendReady) {
+        NSEvent* event;
+        while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
+                                           untilDate:[NSDate distantPast]
+                                              inMode:NSDefaultRunLoopMode
+                                             dequeue:YES])) {
+            [NSApp sendEvent:event];
+        }
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantPast]];
+    }
+}
+
+bool ShouldCloseApp() {
+    return shouldClose;
+}
+
+void PollEvents() {
+    NSEvent* event;
+    while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
+                                       untilDate:nil
+                                          inMode:NSDefaultRunLoopMode
+                                         dequeue:YES])) {
+        [NSApp sendEvent:event];
+    }
+}
+
+bool BeginFrame() {
+    if (shouldClose) return false;
+    currentDrawable = [metalLayer nextDrawable];
+    if (!currentDrawable) return false;
+
+    currentRenderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
+    currentRenderPassDescriptor.colorAttachments[0].texture = currentDrawable.texture;
+    currentRenderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
+    currentRenderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+    currentRenderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(0.45, 0.55, 0.60, 1.0);
+
+    ImGui_ImplMetal_NewFrame(currentRenderPassDescriptor);
+    ImGui_ImplOSX_NewFrame(contentView);
+
+    return true;
+}
+
+void EndFrame() {
+    if (shouldClose || !currentDrawable || !currentRenderPassDescriptor) return;
+
+    id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
+    id<MTLRenderCommandEncoder> encoder = [commandBuffer renderCommandEncoderWithDescriptor:currentRenderPassDescriptor];
+
+    ImGui_ImplMetal_RenderDrawData(ImGui::GetDrawData(), commandBuffer, encoder);
+
+    [encoder endEncoding];
+    [commandBuffer presentDrawable:currentDrawable];
+    [commandBuffer commit];
+
+    currentDrawable = nil;
+    currentRenderPassDescriptor = nil;
+}
+
+void ShutdownBackend() {
+    ImGui_ImplMetal_Shutdown();
+    ImGui_ImplOSX_Shutdown();
+    ImGui::DestroyContext();
+}
+
+void *GetPointerToHgiTextureBackend(pxr::HgiTextureHandle texHandle, float width, float height)
+{
+    id<MTLTexture> mtlTex = (id<MTLTexture>) texHandle->GetRawResource();
+
+    ImVec2 size = ImVec2(width, height); // Set AOV resolution
+    ImTextureID textureID = (__bridge void*)mtlTex;
+    return (void *)textureID;
+}

--- a/src/backends/metal.mm
+++ b/src/backends/metal.mm
@@ -1,155 +1,255 @@
-// backend.mm
 #import <Cocoa/Cocoa.h>
-#import <QuartzCore/CAMetalLayer.h>
 #import <Metal/Metal.h>
+#import <MetalKit/MetalKit.h>
 
 #include "imgui.h"
 #include "imgui_impl_metal.h"
 #include "imgui_impl_osx.h"
 #include "backend.h"
 
-static NSWindow* window = nil;
-static NSView* contentView = nil;
-static CAMetalLayer* metalLayer = nil;
-static id<MTLDevice> device = nil;
-static id<MTLCommandQueue> commandQueue = nil;
-static bool shouldClose = false;
-static bool backendReady = false;
+#include <pxr/imaging/hdx/hgiConversions.h>
+#include <pxr/imaging/hgi/blitCmdsOps.h>
+#include <iostream>
 
-static id<CAMetalDrawable> currentDrawable = nil;
-static MTLRenderPassDescriptor* currentRenderPassDescriptor = nil;
+static void (*AppFrameCallback)() = nullptr;
+static pxr::HgiTextureHandle hgiTexture;
+static const char* appTitle;
+static int appWidth;
+static int appHeight;
 
-@interface AppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+@interface AppViewController : NSViewController<NSWindowDelegate>
 @end
 
-@implementation AppDelegate
-- (void)applicationDidFinishLaunching:(NSNotification*)notification {
-    NSRect frame = NSMakeRect(0, 0, 1280, 720);
-    window = [[NSWindow alloc] initWithContentRect:frame
-                                          styleMask:(NSWindowStyleMaskTitled |
-                                                     NSWindowStyleMaskClosable |
-                                                     NSWindowStyleMaskResizable)
-                                            backing:NSBackingStoreBuffered
-                                              defer:NO];
-    [window setTitle:@"ImGui Metal App"];
-    [window setDelegate:self];
-    [window makeKeyAndOrderFront:nil];
 
-    device = MTLCreateSystemDefaultDevice();
-    commandQueue = [device newCommandQueue];
-
-    contentView = [[NSView alloc] initWithFrame:frame];
-    [window setContentView:contentView];
-
-    metalLayer = [CAMetalLayer layer];
-    metalLayer.device = device;
-    metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-    metalLayer.framebufferOnly = YES;
-    metalLayer.contentsScale = window.backingScaleFactor;
-    metalLayer.frame = contentView.bounds;
-    [contentView setLayer:metalLayer];
-    [contentView setWantsLayer:YES];
-
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-
-    ImGui_ImplMetal_Init(device);
-    ImGui_ImplOSX_Init(contentView);
-
-    backendReady = true;
-}
-
-- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender {
-    return YES;
-}
-
-- (void)windowWillClose:(NSNotification *)notification {
-    shouldClose = true;
-    [metalLayer removeFromSuperlayer];
-    metalLayer = nil;
-    contentView = nil;
-    window = nil;
-}
+@interface AppViewController () <MTKViewDelegate>
+@property (nonatomic, readonly) MTKView *mtkView;
+@property (nonatomic, strong) id <MTLDevice> device;
+@property (nonatomic, strong) id <MTLCommandQueue> commandQueue;
 @end
 
-void InitBackend() {
-    [NSApplication sharedApplication];
-    static AppDelegate* delegate = [[AppDelegate alloc] init];
-    [NSApp setDelegate:delegate];
+@implementation AppViewController
+
+-(instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+
+    _device = MTLCreateSystemDefaultDevice();
+    _commandQueue = [_device newCommandQueue];
+
+    if (!self.device)
+    {
+        NSLog(@"Metal is not supported");
+        abort();
+    }
+
+    // Setup Renderer backend
+    ImGui_ImplMetal_Init(_device);
+
+    return self;
+}
+
+-(MTKView *)mtkView
+{
+    return (MTKView *)self.view;
+}
+
+-(void)loadView
+{
+    self.view = [[MTKView alloc] initWithFrame:CGRectMake(0, 0, appWidth, appHeight)];
+}
+
+-(void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    self.mtkView.device = self.device;
+    self.mtkView.delegate = self;
+
+    ImGui_ImplOSX_Init(self.view);
     [NSApp activateIgnoringOtherApps:YES];
-    [NSApp finishLaunching];
+}
 
-    // Wait until AppDelegate finishes initialization
-    while (!backendReady) {
-        NSEvent* event;
-        while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
-                                           untilDate:[NSDate distantPast]
-                                              inMode:NSDefaultRunLoopMode
-                                             dequeue:YES])) {
-            [NSApp sendEvent:event];
-        }
-        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantPast]];
+-(void)drawInMTKView:(MTKView*)view
+{
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize.x = view.bounds.size.width;
+    io.DisplaySize.y = view.bounds.size.height;
+
+
+    CGFloat framebufferScale = view.window.screen.backingScaleFactor ?: NSScreen.mainScreen.backingScaleFactor;
+
+    io.DisplayFramebufferScale = ImVec2(framebufferScale, framebufferScale);
+
+    id<MTLCommandBuffer> commandBuffer = [self.commandQueue commandBuffer];
+
+    MTLRenderPassDescriptor* renderPassDescriptor = view.currentRenderPassDescriptor;
+    if (renderPassDescriptor == nil)
+    {
+        [commandBuffer commit];
+        return;
     }
-}
 
-bool ShouldCloseApp() {
-    return shouldClose;
-}
+    // Start the Dear ImGui frame
+    ImGui_ImplMetal_NewFrame(renderPassDescriptor);
+    ImGui_ImplOSX_NewFrame(view);
 
-void PollEvents() {
-    NSEvent* event;
-    while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
-                                       untilDate:nil
-                                          inMode:NSDefaultRunLoopMode
-                                         dequeue:YES])) {
-        [NSApp sendEvent:event];
-    }
-}
+    AppFrameCallback();
 
-bool BeginFrame() {
-    if (shouldClose) return false;
-    currentDrawable = [metalLayer nextDrawable];
-    if (!currentDrawable) return false;
+    ImDrawData* draw_data = ImGui::GetDrawData();
 
-    currentRenderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
-    currentRenderPassDescriptor.colorAttachments[0].texture = currentDrawable.texture;
-    currentRenderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
-    currentRenderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
-    currentRenderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(0.45, 0.55, 0.60, 1.0);
+    static ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
+    renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(clear_color.x * clear_color.w, clear_color.y * clear_color.w, clear_color.z * clear_color.w, clear_color.w);
+    id <MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
+    [renderEncoder pushDebugGroup:@"Dear ImGui rendering"];
+    ImGui_ImplMetal_RenderDrawData(draw_data, commandBuffer, renderEncoder);
+    [renderEncoder popDebugGroup];
+    [renderEncoder endEncoding];
 
-    ImGui_ImplMetal_NewFrame(currentRenderPassDescriptor);
-    ImGui_ImplOSX_NewFrame(contentView);
-
-    return true;
-}
-
-void EndFrame() {
-    if (shouldClose || !currentDrawable || !currentRenderPassDescriptor) return;
-
-    id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
-    id<MTLRenderCommandEncoder> encoder = [commandBuffer renderCommandEncoderWithDescriptor:currentRenderPassDescriptor];
-
-    ImGui_ImplMetal_RenderDrawData(ImGui::GetDrawData(), commandBuffer, encoder);
-
-    [encoder endEncoding];
-    [commandBuffer presentDrawable:currentDrawable];
+    // Present
+    [commandBuffer presentDrawable:view.currentDrawable];
     [commandBuffer commit];
-
-    currentDrawable = nil;
-    currentRenderPassDescriptor = nil;
 }
 
-void ShutdownBackend() {
+-(void)mtkView:(MTKView*)view drawableSizeWillChange:(CGSize)size
+{
+}
+
+- (void)viewWillAppear
+{
+    [super viewWillAppear];
+    self.view.window.delegate = self;
+}
+
+- (void)windowWillClose:(NSNotification *)notification
+{
     ImGui_ImplMetal_Shutdown();
     ImGui_ImplOSX_Shutdown();
     ImGui::DestroyContext();
 }
 
-void *GetPointerToHgiTextureBackend(pxr::HgiTextureHandle texHandle, float width, float height)
-{
-    id<MTLTexture> mtlTex = (id<MTLTexture>) texHandle->GetRawResource();
+@end
 
-    ImVec2 size = ImVec2(width, height); // Set AOV resolution
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+@property (nonatomic, strong) NSWindow *window;
+@end
+
+@implementation AppDelegate
+
+-(BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender
+{
+    return YES;
+}
+
+-(instancetype)init
+{
+    if (self = [super init])
+    {
+        NSViewController *rootViewController = [[AppViewController alloc] initWithNibName:nil bundle:nil];
+        self.window = [[NSWindow alloc] initWithContentRect:NSZeroRect
+                                                  styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable
+                                                    backing:NSBackingStoreBuffered
+                                                      defer:NO];
+        self.window.title = [NSString stringWithUTF8String:appTitle];
+        self.window.contentViewController = rootViewController;
+        [self.window center];
+        [self.window makeKeyAndOrderFront:self];
+    }
+    return self;
+}
+
+@end
+
+int InitBackend(const char* title, int width, int height)
+{
+    appTitle = title;
+    appWidth = width;
+    appHeight = height;
+
+    @autoreleasepool
+    {
+        [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+        AppDelegate *appDelegate = [[AppDelegate alloc] init];   // creates window
+        [NSApp setDelegate:appDelegate];
+
+        [NSApp activateIgnoringOtherApps:YES];
+        
+    }
+
+    return 0;
+}
+
+void RunBackend(void (*callback)())
+{
+    AppFrameCallback = callback;
+
+    @autoreleasepool
+    {
+        [NSApp run];
+    }
+}
+
+void ShutdownBackend()
+{ 
+}
+
+void *GetPointerToTextureBackend(pxr::HdRenderBuffer* buffer, pxr::Hgi* hgi)
+{
+    if (!buffer || !buffer->IsConverged()) {
+        std::cerr << "Render buffer not ready." << std::endl;
+        return nullptr;
+    }
+
+    void* pixelData = buffer->Map();
+    int width = buffer->GetWidth();
+    int height = buffer->GetHeight();
+    int depth = buffer->GetDepth();
+    pxr::HdFormat hdFormat = buffer->GetFormat();
+
+    const pxr::GfVec3i dim( width, height, depth);
+
+    const pxr::HgiFormat bufFormat = pxr::HdxHgiConversions::GetHgiFormat(hdFormat);
+    const size_t pixelByteSize = pxr::HdDataSizeOfFormat(hdFormat);
+    const size_t dataByteSize = dim[0] * dim[1] * dim[2] * pixelByteSize;
+
+    // Update the existing texture if specs are compatible. This is more
+    // efficient than re-creating, because the underlying framebuffer that
+    // had the old texture attached would also need to be re-created.
+    if (hgiTexture && hgiTexture->GetDescriptor().dimensions == dim &&
+            hgiTexture->GetDescriptor().format == bufFormat) {
+        pxr::HgiTextureCpuToGpuOp copyOp;
+        copyOp.bufferByteSize = dataByteSize;
+        copyOp.cpuSourceBuffer = pixelData;
+        copyOp.gpuDestinationTexture = hgiTexture;
+        pxr::HgiBlitCmdsUniquePtr blitCmds = hgi->CreateBlitCmds();
+        blitCmds->PushDebugGroup("Update ImGui Image Texture");
+        blitCmds->CopyTextureCpuToGpu(copyOp);
+        blitCmds->PopDebugGroup();
+        hgi->SubmitCmds(blitCmds.get());
+    } else {
+        // Destroy old texture
+        if(hgiTexture) {
+            hgi->DestroyTexture(&hgiTexture);
+        }
+        // Create a new texture
+        pxr::HgiTextureDesc texDesc;
+        texDesc.debugName = "ImGui Image Texture";
+        texDesc.dimensions = dim;
+        texDesc.format = bufFormat;
+        texDesc.initialData = pixelData;
+        texDesc.layerCount = 1;
+        texDesc.mipLevels = 1;
+        texDesc.pixelsByteSize = dataByteSize;
+        texDesc.sampleCount = pxr::HgiSampleCount1;
+        texDesc.usage = pxr::HgiTextureUsageBitsShaderRead;
+
+        hgiTexture = hgi->CreateTexture(texDesc);
+    }
+
+    buffer->Unmap();
+
+    id<MTLTexture> mtlTex = (id<MTLTexture>) hgiTexture->GetRawResource();
     ImTextureID textureID = (__bridge void*)mtlTex;
     return (void *)textureID;
 }

--- a/src/backends/opengl.cpp
+++ b/src/backends/opengl.cpp
@@ -22,12 +22,16 @@ int InitBackend(const char* title, int width, int height)
     // Initialize glfw
     if (!glfwInit()) return -1;
 
+    #if defined(__APPLE__)
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_PROFILE,
-                   GLFW_OPENGL_CORE_PROFILE);             // 3.2+ only
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);  // Required on Mac
-
+                   GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+#else
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+#endif
 
     // Create a GLFW window
     window = glfwCreateWindow(width, height, title, NULL, NULL);
@@ -45,7 +49,11 @@ int InitBackend(const char* title, int width, int height)
     }
 
     // init imgui
+#if defined(__APPLE__)
     const char* glsl_version = "#version 150";
+#else
+    const char* glsl_version = "#version 130";
+#endif
 
     ImGui_ImplOpenGL3_Init(glsl_version);
     ImGui_ImplGlfw_InitForOpenGL(window, true);

--- a/src/backends/opengl.cpp
+++ b/src/backends/opengl.cpp
@@ -1,0 +1,168 @@
+#include "backend.h"
+
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include <imgui.h>
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_opengl3.h>
+#include <imgui_internal.h>
+
+#include "pxr/imaging/hgiGL/texture.h"
+#include "pxr/imaging/hgi/texture.h"
+
+#include <cstdint>
+#include <iostream>
+
+static GLFWwindow* window = nullptr;
+
+/**
+ * @brief Initialize Glfw
+ *
+ * @return a pointer to the current GL context
+ */
+GLFWwindow* InitGlfw(const char* title)
+{
+    // Initialize GLFW
+    if (!glfwInit()) return NULL;
+
+    int width = 1280;
+    int height = 720;
+
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+    glfwWindowHint(GLFW_OPENGL_PROFILE,
+                   GLFW_OPENGL_CORE_PROFILE);             // 3.2+ only
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);  // Required on Mac
+
+
+    // Create a GLFW window
+    GLFWwindow* window = glfwCreateWindow(width, height, title, NULL, NULL);
+    if (!window) {
+        glfwTerminate();
+        return NULL;
+    }
+    glfwMakeContextCurrent(window);
+
+    return window;
+}
+
+/**
+ * @brief initialize Glew
+ *
+ * @return true if Glew was successfully initialized
+ * @return false otherwise
+ */
+bool InitGlew()
+{
+    // Initialize GLEW
+    glewExperimental = GL_TRUE;
+    if (glewInit() != GLEW_OK) {
+        std::cout << "Failed to initialize GLEW" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @brief initialize ImGui
+ *
+ * @param window the current GL context
+ * @return true if ImGui was successfully initialized
+ * @return false otherwise
+ */
+bool InitImGui(GLFWwindow* window)
+{
+    // Initialize ImGui
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    (void)io;
+    io.ConfigFlags |=
+        ImGuiConfigFlags_NavEnableKeyboard;  // Enable Keyboard Controls
+    io.ConfigFlags |=
+        ImGuiConfigFlags_NavEnableGamepad;  // Enable Gamepad Controls
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;  // Enable Docking
+
+    const char* glsl_version = "#version 150";
+
+    ImGui_ImplOpenGL3_Init(glsl_version);
+    ImGui_ImplGlfw_InitForOpenGL(window, true);
+
+    return true;
+}
+
+/**
+ * @brief Terminate Glfw
+ *
+ * @param window the current GL context
+ */
+void TerminateGlfw(GLFWwindow* window)
+{
+    glfwDestroyWindow(window);
+    glfwTerminate();
+}
+
+/**
+ * @brief Terminate ImGui
+ *
+ */
+void TerminateImGui()
+{
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext(NULL);
+}
+
+void InitBackend()
+{
+    const char* TITLE = "ImGui Hydra Editor";
+
+    window = InitGlfw(TITLE);
+    if (!window || !InitGlew() || !InitImGui(window)){
+        std::cout << "Failed to initialize the window" << std::endl;
+        return;
+    }
+
+    glEnable(GL_DEPTH_TEST);
+}
+
+void ShutdownBackend()
+{
+    TerminateImGui();
+    TerminateGlfw(window);
+}
+
+bool ShouldCloseApp()
+{
+    return glfwWindowShouldClose(window);
+}
+
+void PollEvents()
+{
+    glfwPollEvents();
+}
+
+bool BeginFrame()
+{
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplGlfw_NewFrame();
+
+    return true;
+}
+
+void EndFrame()
+{
+    glClearColor(0.45f, 0.55f, 0.60f, 1.00f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+    glfwSwapBuffers(window);
+}
+
+void *GetPointerToHgiTextureBackend(pxr::HgiTextureHandle texHandle, float width, float height)
+{
+    pxr::HgiGLTexture* srcTexture = static_cast<pxr::HgiGLTexture*>(texHandle.Get());
+
+    return (void*) srcTexture->GetTextureId();
+}

--- a/src/engine.h
+++ b/src/engine.h
@@ -9,9 +9,6 @@
  */
 #pragma once
 
-// #include <GL/glew.h>
-// #include <GLFW/glfw3.h>
-
 #include <pxr/base/tf/token.h>
 #include <pxr/imaging/hd/engine.h>
 #include <pxr/imaging/hd/pluginRenderDelegateUniqueHandle.h>

--- a/src/engine.h
+++ b/src/engine.h
@@ -9,15 +9,16 @@
  */
 #pragma once
 
+// #include <GL/glew.h>
+// #include <GLFW/glfw3.h>
+
 #include <pxr/base/tf/token.h>
-#include <pxr/imaging/glf/drawTarget.h>
 #include <pxr/imaging/hd/engine.h>
 #include <pxr/imaging/hd/pluginRenderDelegateUniqueHandle.h>
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/imaging/hd/sceneIndex.h>
 #include <pxr/imaging/hdx/taskController.h>
 #include <pxr/imaging/hgi/hgi.h>
-#include <pxr/imaging/hgiInterop/hgiInterop.h>
 #include <pxr/usd/usd/prim.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -126,7 +127,6 @@ class Engine {
 
     private:
         UsdStageRefPtr _stage;
-        GlfDrawTargetRefPtr _drawTarget;
         GfMatrix4d _camView, _camProj;
         int _width, _height;
 
@@ -141,7 +141,6 @@ class Engine {
         HdSceneIndexBaseRefPtr _sceneIndex;
         SdfPath _taskControllerId;
 
-        HgiInterop _interop;
         HdxSelectionTrackerSharedPtr _selTracker;
 
         TfToken _curRendererPlugin;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,41 +8,50 @@
 #include "mainwindow.h"
 #include "models/model.h"
 #include "style/imgui_spectrum.h"
-
+#include "backends/backend.h"
 
 #include <iostream>
-#include "backends/backend.h"
+
+static pxr::Model model;
+static pxr::MainWindow* mainWindow;
+
+/**
+ * @brief The function called every frame by the backend.
+ */
+void run()
+{
+    ImGui::NewFrame();
+    mainWindow->Update();
+    ImGui::Render();
+}
 
 int main(int argc, const char** argv)
 {
-    InitBackend();
+    const char* TITLE = "ImGui Hydra Editor";
+    int WIDTH = 1280;
+    int HEIGHT = 720;
 
-    ImGuiIO& io = ImGui::GetIO();
-    (void)io;
-    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
-    io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
-    ImGui::Spectrum::StyleColorsSpectrum();
-
-    LoadDefaultOrCustomLayout();
-
-    pxr::Model model;
-    pxr::MainWindow mainWindow(&model);
-
-    while (!ShouldCloseApp()) {
-        PollEvents();
-        if (!BeginFrame()) continue;
-
-        ImGui::NewFrame();
-
-        mainWindow.Update();
-
-        ImGui::Render();
-
-        EndFrame();
+    if (InitBackend(TITLE, WIDTH, HEIGHT) != 0)
+    {
+        std::cerr << "Error while initializing backend; exiting." << std::endl;
+        return -1;
     }
 
+    mainWindow = new pxr::MainWindow(&model);
+
+    ImGui::Spectrum::StyleColorsSpectrum();
+    LoadDefaultOrCustomLayout();
+
+    RunBackend(run);
+
     ShutdownBackend();
+
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,161 +1,38 @@
-/**
- * @file main.cpp
- * @author Raphael Jouretz (rjouretz.com)
- * @brief main file containing the main function.
- *
- * @copyright Copyright (c) 2023
- *
- */
+// main.cpp
 
-#include <GL/glew.h>
-#include <GLFW/glfw3.h>
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui.h>
-#include <imgui_impl_glfw.h>
-#include <imgui_impl_opengl3.h>
 #include <imgui_internal.h>
-
-#include <iostream>
-#include <ostream>
 
 #include "layouts/layout.h"
 #include "mainwindow.h"
 #include "models/model.h"
 #include "style/imgui_spectrum.h"
 
-/**
- * @brief Initialize Glfw
- *
- * @return a pointer to the current GL context
- */
-GLFWwindow* InitGlfw(const char* title)
+
+#include <iostream>
+#include "backends/backend.h"
+
+int main(int argc, const char** argv)
 {
-    // Initialize GLFW
-    if (!glfwInit()) return NULL;
+    InitBackend();
 
-    int width = 1280;
-    int height = 720;
-
-#if defined(__APPLE__)
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
-    glfwWindowHint(GLFW_OPENGL_PROFILE,
-                   GLFW_OPENGL_CORE_PROFILE);             // 3.2+ only
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);  // Required on Mac
-#else
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
-    // glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 3.2+
-    // only glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE); // 3.0+ only
-#endif
-
-    // Create a GLFW window
-    GLFWwindow* window = glfwCreateWindow(width, height, title, NULL, NULL);
-    if (!window) {
-        glfwTerminate();
-        return NULL;
-    }
-    glfwMakeContextCurrent(window);
-
-    return window;
-}
-
-/**
- * @brief initialize Glew
- *
- * @return true if Glew was successfully initialized
- * @return false otherwise
- */
-bool InitGlew()
-{
-    // Initialize GLEW
-    glewExperimental = GL_TRUE;
-    if (glewInit() != GLEW_OK) {
-        std::cout << "Failed to initialize GLEW" << std::endl;
-        return false;
-    }
-    return true;
-}
-
-/**
- * @brief initialize ImGui
- *
- * @param window the current GL context
- * @return true if ImGui was successfully initialized
- * @return false otherwise
- */
-bool InitImGui(GLFWwindow* window)
-{
-    // Initialize ImGui
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
     (void)io;
-    io.ConfigFlags |=
-        ImGuiConfigFlags_NavEnableKeyboard;  // Enable Keyboard Controls
-    io.ConfigFlags |=
-        ImGuiConfigFlags_NavEnableGamepad;  // Enable Gamepad Controls
-    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;  // Enable Docking
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
     ImGui::Spectrum::StyleColorsSpectrum();
 
-#if defined(__APPLE__)
-    const char* glsl_version = "#version 150";
-#else
-    const char* glsl_version = "#version 130";
-#endif
-
-    ImGui_ImplOpenGL3_Init(glsl_version);
-    ImGui_ImplGlfw_InitForOpenGL(window, true);
-
     LoadDefaultOrCustomLayout();
-
-    return true;
-}
-
-/**
- * @brief Terminate Glfw
- *
- * @param window the current GL context
- */
-void TerminateGlfw(GLFWwindow* window)
-{
-    glfwDestroyWindow(window);
-    glfwTerminate();
-}
-
-/**
- * @brief Terminate ImGui
- *
- */
-void TerminateImGui()
-{
-    ImGui_ImplOpenGL3_Shutdown();
-    ImGui_ImplGlfw_Shutdown();
-    ImGui::DestroyContext(NULL);
-}
-
-/**
- * @brief Main function
- *
- */
-int main(int argc, char** argv)
-{
-    const char* TITLE = "ImGui Hydra Editor";
-
-    GLFWwindow* window = InitGlfw(TITLE);
-    if (!window || !InitGlew() || !InitImGui(window)) return 1;
-
-    glEnable(GL_DEPTH_TEST);
 
     pxr::Model model;
     pxr::MainWindow mainWindow(&model);
 
-    while (!glfwWindowShouldClose(window)) {
-        glfwPollEvents();
-
-        ImGui_ImplOpenGL3_NewFrame();
-        ImGui_ImplGlfw_NewFrame();
+    while (!ShouldCloseApp()) {
+        PollEvents();
+        if (!BeginFrame()) continue;
 
         ImGui::NewFrame();
 
@@ -163,15 +40,9 @@ int main(int argc, char** argv)
 
         ImGui::Render();
 
-        glClearColor(0.45f, 0.55f, 0.60f, 1.00f);
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-        glfwSwapBuffers(window);
+        EndFrame();
     }
 
-    TerminateImGui();
-    TerminateGlfw(window);
-
+    ShutdownBackend();
     return 0;
 }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -16,16 +16,6 @@ Model::Model()
     SetEditableSceneIndex(_editableSceneIndex);
 }
 
-UsdStageRefPtr Model::GetStage()
-{
-    return _stage;
-}
-
-void Model::SetStage(UsdStageRefPtr stage)
-{
-    _stage = stage;
-}
-
 void Model::AddSceneIndexBase(HdSceneIndexBaseRefPtr sceneIndex)
 {
     _sceneIndexBases->AddInputScene(sceneIndex, SdfPath::AbsoluteRootPath());
@@ -52,16 +42,6 @@ HdSceneIndexBaseRefPtr Model::GetFinalSceneIndex()
 HdSceneIndexPrim Model::GetPrim(SdfPath primPath)
 {
     return _finalSceneIndex->GetPrim(primPath);
-}
-
-UsdPrim Model::GetUsdPrim(SdfPath path)
-{
-    return _stage->GetPrimAtPath(path);
-}
-
-UsdPrimRange Model::GetAllPrims()
-{
-    return _stage->Traverse();
 }
 
 SdfPathVector Model::GetCameras()

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -38,20 +38,6 @@ class Model {
         Model();
 
         /**
-         * @brief Get a reference to the Usd Stage from the model
-         *
-         * @return UsdStageRefPtr a reference to the Usd Stage
-         */
-        UsdStageRefPtr GetStage();
-
-        /**
-         * @brief Set a reference of a Usd Stage to the model
-         *
-         * @param stage UsdStageRefPtr a reference to the Usd Stage
-         */
-        void SetStage(UsdStageRefPtr stage);
-
-        /**
          * @brief Add a Scene Index Base to the model
          *
          * @param sceneIndex HdSceneIndexBaseRefPtr Scene Index to add
@@ -89,22 +75,6 @@ class Model {
         HdSceneIndexPrim GetPrim(SdfPath primPath);
 
         /**
-         * @brief Get the Usd Prim from the model at a specific path
-         *
-         * @param primPath SdfPath the path to the prim to get
-         *
-         * @return UsdPrim the Usd Prim at the given path
-         */
-        UsdPrim GetUsdPrim(SdfPath primPath);
-
-        /**
-         * @brief Get the Usd Prim from the model
-         *
-         * @return UsdPrimRange a prim
-         */
-        UsdPrimRange GetAllPrims();
-
-        /**
          * @brief Get a vector of all camera path from the model
          *
          * @return SdfPathVector a vector of camera paths
@@ -126,7 +96,6 @@ class Model {
         void SetSelection(SdfPathVector primPaths);
 
     private:
-        UsdStageRefPtr _stage;
         SdfPathVector _selection;
         HdSceneIndexBaseRefPtr _editableSceneIndex;
         HdMergingSceneIndexRefPtr _sceneIndexBases, _finalSceneIndex;

--- a/src/views/usdsessionlayer.cpp
+++ b/src/views/usdsessionlayer.cpp
@@ -117,8 +117,6 @@ void UsdSessionLayer::_SetEmptyStage()
     _stage->SetEditTarget(_sessionLayer);
     _stageSceneIndex->SetStage(_stage);
     _stageSceneIndex->SetTime(UsdTimeCode::Default());
-
-    GetModel()->SetStage(_stage);
 }
 
 void UsdSessionLayer::_LoadUsdStage(const string usdFilePath)
@@ -136,8 +134,6 @@ void UsdSessionLayer::_LoadUsdStage(const string usdFilePath)
     _stage->SetEditTarget(_sessionLayer);
     _stageSceneIndex->SetStage(_stage);
     _stageSceneIndex->SetTime(UsdTimeCode::Default());
-
-    GetModel()->SetStage(_stage);
 }
 
 string UsdSessionLayer::_GetNextAvailableIndexedPath(string primPath)

--- a/src/views/usdsessionlayer.cpp
+++ b/src/views/usdsessionlayer.cpp
@@ -108,6 +108,7 @@ void UsdSessionLayer::_Draw()
 
 void UsdSessionLayer::_SetEmptyStage()
 {
+    _ClearStage();
     _stage = UsdStage::CreateInMemory();
     UsdGeomSetStageUpAxis(_stage, UsdGeomTokens->y);
 
@@ -119,6 +120,17 @@ void UsdSessionLayer::_SetEmptyStage()
     _stageSceneIndex->SetTime(UsdTimeCode::Default());
 }
 
+void UsdSessionLayer::_ClearStage()
+{
+    if(!_stage) {
+        return;
+    }
+
+    for (auto prim : _stage->GetPseudoRoot().GetChildren()) {
+        _stage->RemovePrim(prim.GetPath());
+    }
+}
+
 void UsdSessionLayer::_LoadUsdStage(const string usdFilePath)
 {
     if (!ifstream(usdFilePath)) {
@@ -128,6 +140,7 @@ void UsdSessionLayer::_LoadUsdStage(const string usdFilePath)
         return;
     }
 
+    _ClearStage();
     _rootLayer = SdfLayer::FindOrOpen(usdFilePath);
     _sessionLayer = SdfLayer::CreateAnonymous();
     _stage = UsdStage::Open(_rootLayer, _sessionLayer);

--- a/src/views/usdsessionlayer.h
+++ b/src/views/usdsessionlayer.h
@@ -77,6 +77,12 @@ class UsdSessionLayer : public View {
         void _SetEmptyStage();
 
         /**
+         * @brief Clear the loaded stage
+         *
+         */
+        void _ClearStage();
+
+        /**
          * @brief Check if USD session layer was updated since the last load
          * (different)
          *

--- a/src/views/viewport.cpp
+++ b/src/views/viewport.cpp
@@ -309,7 +309,7 @@ void Viewport::_ZoomActiveCam(ImVec2 mouseDeltaPos)
 void Viewport::_ZoomActiveCam(float scrollWheel)
 {
     GfVec3d camFront = (_at - _eye).GetNormalized();
-    _eye += camFront * scrollWheel / 10.f;
+    _eye += camFront * scrollWheel;
 
     _UpdateActiveCamFromViewport();
 }

--- a/src/views/viewport.cpp
+++ b/src/views/viewport.cpp
@@ -195,7 +195,6 @@ void Viewport::_UpdateHydraRender()
     // do the render
     _engine->Render();
 
-    // create an imgui image with the drawtarget color data
     void* id = _engine->GetRenderBufferData();
     ImGui::Image(id, ImVec2(width, height), ImVec2(0, 1), ImVec2(1, 0));
 }

--- a/src/views/viewport.cpp
+++ b/src/views/viewport.cpp
@@ -174,14 +174,6 @@ void Viewport::_ConfigureImGuizmo()
 void Viewport::_UpdateGrid()
 {
     _gridSceneIndex->Populate(_isGridEnabled);
-
-    if (!_isGridEnabled) return;
-
-    GfMatrix4f viewF(_getCurViewMatrix());
-    GfMatrix4f projF(_proj);
-    GfMatrix4f identity(1);
-
-    ImGuizmo::DrawGrid(viewF.data(), projF.data(), identity.data(), 10);
 }
 
 void Viewport::_UpdateHydraRender()

--- a/vendors/CMakeLists.txt
+++ b/vendors/CMakeLists.txt
@@ -1,6 +1,9 @@
-add_subdirectory(glew)
-add_subdirectory(glfw)
 add_subdirectory(imgui)
 add_subdirectory(imguizmo)
 add_subdirectory(imguicolortextedit)
 add_subdirectory(imguifiledialog)
+
+if((NOT APPLE) OR FORCE_OPENGL)
+    add_subdirectory(glew)
+    add_subdirectory(glfw)
+endif()

--- a/vendors/imgui/CMakeLists.txt
+++ b/vendors/imgui/CMakeLists.txt
@@ -18,6 +18,8 @@ set(PUBLIC_HEADERS
     "imgui/imgui.h"
 )
 
+set(TARGET_LIBS)
+
 # Add the backend for the graphics according to the OS
 if(APPLE AND NOT FORCE_OPENGL)
     list(APPEND SRC_CPP
@@ -37,6 +39,7 @@ else()
         "imgui/backends/imgui_impl_opengl3.h"
         "imgui/backends/imgui_impl_glfw.h"
     )
+    list(APPEND TARGET_LIBS glfw)
 endif()
 
 add_library(${PROJECT_NAME} ${SRC_CPP} ${H_CPP} ${PUBLIC_HEADER})
@@ -54,7 +57,7 @@ target_include_directories(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        glfw
+        ${TARGET_LIBS}
 )
 set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/vendors/imgui/CMakeLists.txt
+++ b/vendors/imgui/CMakeLists.txt
@@ -6,8 +6,6 @@ set(SRC_CPP
     "imgui/imgui_draw.cpp"
     "imgui/imgui_widgets.cpp"
     "imgui/imgui_tables.cpp"
-    "imgui/backends/imgui_impl_opengl3.cpp"
-    "imgui/backends/imgui_impl_glfw.cpp"
     "imgui/misc/cpp/imgui_stdlib.cpp"
 )
 
@@ -18,9 +16,28 @@ set(H_CPP
 
 set(PUBLIC_HEADERS 
     "imgui/imgui.h"
-    "imgui/backends/imgui_impl_opengl3.h"
-    "imgui/backends/imgui_impl_glfw.h"
 )
+
+# Add the backend for the graphics according to the OS
+if(APPLE AND NOT FORCE_OPENGL)
+    list(APPEND SRC_CPP
+        "imgui/backends/imgui_impl_metal.mm"
+        "imgui/backends/imgui_impl_osx.mm"
+    )
+    list(APPEND PUBLIC_HEADERS
+        "imgui/backends/imgui_impl_metal.h"
+        "imgui/backends/imgui_impl_osx.h"
+    )
+else()
+    list(APPEND SRC_CPP
+        "imgui/backends/imgui_impl_opengl3.cpp"
+        "imgui/backends/imgui_impl_glfw.cpp"
+    )
+    list(APPEND PUBLIC_HEADERS
+        "imgui/backends/imgui_impl_opengl3.h"
+        "imgui/backends/imgui_impl_glfw.h"
+    )
+endif()
 
 add_library(${PROJECT_NAME} ${SRC_CPP} ${H_CPP} ${PUBLIC_HEADER})
 

--- a/vendors/imguicolortextedit/CMakeLists.txt
+++ b/vendors/imguicolortextedit/CMakeLists.txt
@@ -23,7 +23,6 @@ target_include_directories(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        glfw
         imgui
 )
 set_target_properties(${PROJECT_NAME}

--- a/vendors/imguifiledialog/CMakeLists.txt
+++ b/vendors/imguifiledialog/CMakeLists.txt
@@ -23,7 +23,6 @@ target_include_directories(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        glfw
         imgui
 )
 set_target_properties(${PROJECT_NAME}

--- a/vendors/imguizmo/CMakeLists.txt
+++ b/vendors/imguizmo/CMakeLists.txt
@@ -25,7 +25,6 @@ target_include_directories(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        glfw
         imgui
 )
 set_target_properties(${PROJECT_NAME}


### PR DESCRIPTION
Proposal to replace OpenGL call by native backend (currently Metal for Mac, OpenGL otherwise).

We can still build with OpenGL on Mac by adding the cmake flag `-DFORCE_OPENGL=ON`

Now, main.cpp is pretty straightforward and call backend functions from src/backends/backend.h.
Cmake will select the associated implementation at compile time (src/backends/metal.mm or opengl.cpp).
The backend contains functions to init/run/shutdown the backend.

It also implements a function (GetPointerToTextureBackend) that gets the result from the render and will create a texture according to the current backend. This texture will then be presented to Imgui in order to display it as ImGui::Image accepts texture from current backend.